### PR TITLE
为道具下拉列表内容进行排序

### DIFF
--- a/res/ItemBoxEditor.lua
+++ b/res/ItemBoxEditor.lua
@@ -41,6 +41,7 @@ local pouchItemArray = nil
 local cItemParam = nil
 local cBasicParam = nil
 
+local existedItems = {}
 local existedComboLabels = {}
 local existedComboItemIdFixedValues = {}
 local existedComboItemNumValues = {}
@@ -185,10 +186,8 @@ local function initBoxItem()
             else
                 itemName = tostring(boxItem:get_field("ItemIdFixed"))
             end
-            local comboxItem = itemName .. " - " .. boxItem:get_field("Num")
-            existedComboLabels[existedShowInComboxPosIndex] = comboxItem
-            existedComboItemIdFixedValues[existedShowInComboxPosIndex] = boxItem:get_field("ItemIdFixed")
-            existedComboItemNumValues[existedShowInComboxPosIndex] = boxItem:get_field("Num")
+            local comboxItem = itemName .. "[" .. tostring(boxItem:get_field("ItemIdFixed")) .. "] - " .. boxItem:get_field("Num")
+            existedItems[existedShowInComboxPosIndex] = {name = comboxItem, fixedId = boxItem:get_field("ItemIdFixed"), num = boxItem:get_field("Num")}
 
             -- adjust the max item count in Item Add func
             addNewItemListMaxCount[tostring(boxItem:get_field("ItemIdFixed"))] = addNewItemListMaxCount
@@ -196,6 +195,12 @@ local function initBoxItem()
 
             existedShowInComboxPosIndex = existedShowInComboxPosIndex + 1
         end
+    end
+    table.sort(existedItems, function(a,b) return a.fixedId < b.fixedId end)
+    for itemIndex = 0, #existedItems - 1 do
+        existedComboLabels[itemIndex + 1] = existedItems[itemIndex + 1].name
+        existedComboItemIdFixedValues[itemIndex + 1] = existedItems[itemIndex + 1].fixedId
+        existedComboItemNumValues[itemIndex + 1] = existedItems[itemIndex + 1].num
     end
 end
 


### PR DESCRIPTION
拯救一下眼睛，找道具找得有点眼花

已存在的道具下拉列表里道具排序没有规律，字又小又看不清，遂按物品 id 做了一个排序，顺便增加了在列表中显示道具 id

- feat: show item id and sorting the item list

![屏幕截图 2025-03-04 060244](https://github.com/user-attachments/assets/dbd137c4-7798-45a9-9fbe-73fd1fef7dd3)
