### PR TITLE
新增道具表工具窗口，重构窗口渲染逻辑

### DIFF
--- a/res/ItemBoxEditor.lua
+++ b/res/ItemBoxEditor.lua
@@ -43,7 +43,13 @@ local addNewItemNameList = {}
 
 -- window status
 local mainWindowOpen = true
+local itemWindowOpen = true
 -- window status end
+
+-- item table window
+local searchItemTarget = nil
+local searchItemResult = {}
+-- item table window end
 
 local boxItemArray = nil
 local pouchItemArray = nil
@@ -179,6 +185,30 @@ local function loadI18NJson(jsonPath)
     end
 end
 
+local function searchItemList(target)
+    local itemIndex = 0
+    local itemMap = {}
+    for key, value in pairs(itemNameJson) do
+        if checkItemName(value) then
+            if target ~= nil then
+                if string.lower(value):match(string.lower(target)) then
+                    itemMap[itemIndex] = {key = tonumber(key), value = value}
+                    itemIndex = itemIndex + 1
+                end
+            else
+                itemMap[itemIndex] = {key = tonumber(key), value = value}
+                itemIndex = itemIndex + 1
+            end
+        end
+    end
+
+    table.sort(itemMap, function(a, b)
+        return a.key < b.key
+    end)
+
+    return itemMap
+end
+
 local function initBoxItem()
     local saveDataManager = sdk.get_managed_singleton("app.SaveDataManager")
     local cUserSaveParam = saveDataManager:call("getCurrentUserSaveData")
@@ -285,7 +315,7 @@ local function init()
     existedSelectedItemNum = existedComboItemNumValues[1]
 end
 
-local function main() 
+local function mainWindow() 
     if imgui.begin_window(i18n.windowTitle, mainWindowOpen, ImGuiWindowFlags_AlwaysAutoResize) then
         if MAX_VER_LT_OR_EQ_GAME_VER == false then
             imgui.text_colored(i18n.compatibleWarning, ERROR_COLOR)
@@ -401,7 +431,64 @@ local function main()
     end
 end
 
+local function itemTableWindow()
+    local changed = nil
+    if imgui.begin_window(i18n.itemTableWindowTitle, itemWindowOpen, ImGuiWindowFlags_AlwaysAutoResize) then
+        imgui.text(i18n.itemTableWindowTitle)
+        imgui.begin_table('search-group', 2, ImGuiTableFlags_NoSavedSettings)
+        imgui.table_setup_column('', 0, 2)
+        imgui.table_setup_column('', 0, 1)
+
+        imgui.table_next_column()
+        imgui.push_item_width(-1)
+        changed, searchItem = imgui.input_text('', searchItemTarget)
+        imgui.pop_item_width()
+        if changed then
+            searchItemTarget = searchItem
+        end
+
+        imgui.table_next_column()
+        if imgui.button(i18n.clearBtn, {-0.001, 0}) then
+            searchItemTarget = nil
+            searchItemResult = searchItemList(searchItemTarget)
+        end
+        imgui.end_table()
+
+        if imgui.button(i18n.searchBtn, {-0.001, 0}) then
+            searchItemResult = searchItemList(searchItemTarget)
+        end
+
+        imgui.begin_table('table', 2, 17) -- 17 is ImGuiTableFlags_Resizable | ImGuiTableFlags_NoSavedSettings
+
+        imgui.table_setup_column('', 0, 1)
+        imgui.table_setup_column('', 0, 2)
+
+        imgui.push_style_color(21, 0xff142D65)
+        imgui.push_style_color(22, 0xff142D65)
+        imgui.push_style_color(23, 0xff142D65)
+        imgui.table_next_column()
+        imgui.button(i18n.itemTableTitleID, {-0.001, 0})
+        imgui.table_next_column()
+        imgui.button(i18n.itemTableTitleName, {-0.001, 0})
+        imgui.pop_style_color(3)
+
+        for i = 1, #searchItemResult do
+            imgui.table_next_column()
+            imgui.button(searchItemResult[i].key, {-0.001, 0})
+            imgui.table_next_column()
+            imgui.button(searchItemResult[i].value, {-0.001, 0})
+        end
+
+        imgui.end_table()
+        
+        imgui.end_window()
+    else
+        itemWindowOpen = false
+    end
+end
+
 loadI18NJson(ITEM_NAME_JSON_PATH)
+searchItemResult = searchItemList(searchItemTarget)
 getVersion()
 MAX_VER_LT_OR_EQ_GAME_VER = compareVersions(GAME_VER, MAX_VERSION)
 
@@ -409,7 +496,8 @@ re.on_draw_ui(function()
     local changed = false
 
     if imgui.tree_node(i18n.title) then
-        changed, mainWindowOpen = imgui.checkbox("Open Editor", i18n.openMainWindow)
+        changed, mainWindowOpen = imgui.checkbox(i18n.openMainWindow, mainWindowOpen)
+        changed, itemWindowOpen = imgui.checkbox(i18n.openItemTableWindow, itemWindowOpen)
 
         imgui.tree_pop()
     end
@@ -423,7 +511,8 @@ re.on_frame(function()
 
     -- only display the window when REFramework is actually drawing its own UI
     if reframework:is_drawing_ui() then
-        main()
+        mainWindow()
+        itemTableWindow()
     end
 
     -- reset the font at the frame end

--- a/res/ItemBoxEditor.lua
+++ b/res/ItemBoxEditor.lua
@@ -427,6 +427,7 @@ local function mainWindow()
 
         imgui.end_window()
     else
+        clear()
         mainWindowOpen = false
     end
 end

--- a/res/i18n/EN-US.json
+++ b/res/i18n/EN-US.json
@@ -1,4 +1,6 @@
 {
+  "title": "ItemBox Editor",
+  "openMainWindow": "Open ItemBox Editor",
   "windowTitle": "ItemBox Editor",
   "compatibleWarning": "[Warning] Your game version is NOT compatible with this mod: ",
   "gameVersion": "Game Version",

--- a/res/i18n/EN-US.json
+++ b/res/i18n/EN-US.json
@@ -1,7 +1,9 @@
 {
   "title": "ItemBox Editor",
   "openMainWindow": "Open ItemBox Editor",
+  "openItemTableWindow": "Open Item Table",
   "windowTitle": "ItemBox Editor",
+  "itemTableWindowTitle": "Item Table",
   "compatibleWarning": "[Warning] Your game version is NOT compatible with this mod: ",
   "gameVersion": "Game Version",
   "modVersion": "MOD Version",
@@ -28,5 +30,9 @@
   "coinSlider": "Select New Money",
   "coinBtn": "Confirm Money Edit",
   "ptsSlider": "Select New Points",
-  "ptsBtn": "Confirm Points Edit"
+  "ptsBtn": "Confirm Points Edit",
+  "clearBtn": "Clear",
+  "searchBtn": "Search",
+  "itemTableTitleID": "Item ID",
+  "itemTableTitleName": "Item Name"
 }

--- a/res/i18n/ZH-Hans.json
+++ b/res/i18n/ZH-Hans.json
@@ -1,7 +1,9 @@
 {
   "title": "道具箱编辑器",
   "openMainWindow": "打开道具箱编辑器",
+  "openItemTableWindow": "打开道具表",
   "windowTitle": "道具箱编辑器",
+  "itemTableWindowTitle": "道具表",
   "compatibleWarning": "[警告] 当前的游戏版本不兼容该MOD: ",
   "gameVersion": "游戏版本",
   "modVersion": "MOD版本",
@@ -28,5 +30,9 @@
   "coinSlider": "选择新的金币数量",
   "coinBtn": "确认金币修改",
   "ptsSlider": "选择新的调查点数",
-  "ptsBtn": "确认调查点数修改"
+  "ptsBtn": "确认调查点数修改",
+  "clearBtn": "清空",
+  "searchBtn": "搜索",
+  "itemTableTitleID": "物品ID",
+  "itemTableTitleName": "物品名称"
 }

--- a/res/i18n/ZH-Hans.json
+++ b/res/i18n/ZH-Hans.json
@@ -1,4 +1,6 @@
 {
+  "title": "道具箱编辑器",
+  "openMainWindow": "打开道具箱编辑器",
   "windowTitle": "道具箱编辑器",
   "compatibleWarning": "[警告] 当前的游戏版本不兼容该MOD: ",
   "gameVersion": "游戏版本",


### PR DESCRIPTION
**新增道具表页面**

便于搜索道具 ID，如图

![屏幕截图 2025-03-05 060420](https://github.com/user-attachments/assets/230b4cf3-ce29-4131-b1c3-f6a626b41f45)

**在 Script Generated UI 菜单中添加窗口控制项**

允许单独关闭小窗口，如图

![屏幕截图 2025-03-05 060415](https://github.com/user-attachments/assets/bc8e1f13-f487-468e-bea2-0b5348757bf2)

**重构窗口渲染逻辑**

根据文档描述，`on_draw_ui` 事件中不建议使用 `begin_window`创建窗口，故将此部分重构

> imgui.begin_window(name, open, flags)
>Creates a new window with the title of name.
>
>open is a bool. Can be nil. If not nil, a close button will be shown in the top right of the window.
>
>flags - ImGuiWindowFlags.
>
>begin_window must have a corresponding end_window call.
>
>This function may only be called in on_frame, not on_draw_ui.
>
>Returns a bool. Returns false if the user wants to close the window.

重构方案是将原本在`on_draw_ui`中创建窗口相关的代码包装成 `mainWindow` 函数，然后通过`on_frame`事件进行渲染

现在在关闭编辑窗口后会清理编辑窗口相关的数据，重新打开窗口需要重新读取道具箱，这个修改是遇到以下情况才考虑增加的：

a. 读取道具箱
b. 隐藏 REF
c. 进行游戏，道具箱数据发生改变，之前没有的道具出现了
d. 打开 REF，道具箱数据还是旧数据，新增的道具没有出现

**修复代码隐患**

`imgui.begin_window`方法可以提供三个入参：name, open, flags，旧代码中忽略了 open 参数直接传入 flags，遂进行修正

```diff
- imgui.begin_window(i18n.windowTitle, ImGuiWindowFlags_AlwaysAutoResize)
+ if imgui.begin_window(i18n.windowTitle, mainWindowOpen, ImGuiWindowFlags_AlwaysAutoResize) then
```


- feat: split tools into separate windows
- feat: add item table page
- feat: clear data when close editer window