### PR TITLE
新增了添加物品到道具箱的功能

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,10 +1,10 @@
 ### 版本下载 / Release Downloads
 > 目录中包含物品ID列表 / The  directory contains item ID list.
-- **[BoxItemEditor_EN-US.zip](https://github.com/dzxrly/MHWS-BoxItemEditor/releases/download/v1.3/BoxItemEditor_EN-US.zip)** （英文版 / English Version）
-- **[BoxItemEditor_ZH-Hans.zip](https://github.com/dzxrly/MHWS-BoxItemEditor/releases/download/v1.3/BoxItemEditor_ZH-Hans.zip)** （简体中文版 / Simplified Chinese Version）
+- **[BoxItemEditor_EN-US.zip](https://github.com/Cliencer/MHWS-BoxItemEditor/releases/download/1.4/BoxItemEditor_EN-US.zip)** （英文版 / English Version）
+- **[BoxItemEditor_ZH-Hans.zip](https://github.com/Cliencer/MHWS-BoxItemEditor/releases/download/1.4/BoxItemEditor_ZH-Hans.zip)** （简体中文版 / Simplified Chinese Version）
 
 ### 文件校验 / Checksums
-- `BoxItemEditor_EN-US.zip` SHA-256: 876ba84fc30cdedad9ca7eaaed531c48be6ddc8ca492f261e1ceffc3d840f752
-- `BoxItemEditor_ZH-Hans.zip` SHA-256: fe06511f96c8a3a4674b75cb152b1b0de41cfe89f6ff5bd4c2bc4cb74c5ce2a1
+- `BoxItemEditor_EN-US.zip` SHA-256: 5b7359e283560f52018efc4385ba01a464901d519ffa6fe8f6ca47509806fade
+- `BoxItemEditor_ZH-Hans.zip` SHA-256: ef2661247c3f493fa42efbf5635872643d0aeef96fae8d744d2bb0c58ab42cf1
 ### 打包时间 / Build Time
-- Wed Mar  5 05:10:09 UTC 2025
+- Wed Mar  5 07:52:04 UTC 2025

--- a/src/i18n/EN-US.json
+++ b/src/i18n/EN-US.json
@@ -34,5 +34,7 @@
   "clearBtn": "Clear",
   "searchBtn": "Search",
   "itemTableTitleID": "Item ID",
-  "itemTableTitleName": "Item Name"
+  "itemTableTitleName": "Item Name",
+  "unknownItem":"Unknown Item",
+  "searchInput":"Search Item with Name/ID/Num"
 }

--- a/src/i18n/ZH-Hans.json
+++ b/src/i18n/ZH-Hans.json
@@ -34,5 +34,7 @@
   "clearBtn": "清空",
   "searchBtn": "搜索",
   "itemTableTitleID": "物品ID",
-  "itemTableTitleName": "物品名称"
+  "itemTableTitleName": "物品名称",
+  "unknownItem":"未知物品",
+  "searchInput":"搜索物品名称/ID/数量"
 }


### PR DESCRIPTION
新增了添加物品到道具箱的功能，同时删去了添加物品到道具栏的功能。

通过调用原生方法添加道具箱物品，经过测试可以正常添加物品到道具箱，新添加物品需要退出道具箱页面重进才能看到。
具体的方法是`cItemParam`下的`changeItemBoxNum`方法，有两个参数，第一个参数是物品`fixId`，第二个参数是改变的数量`changedNumber`（可以为负值）。