### PR TITLE
设定首次安装时道具表的窗口尺寸

### DIFF
--- a/src/ItemBoxEditor.lua
+++ b/src/ItemBoxEditor.lua
@@ -435,8 +435,8 @@ end
 
 local function itemTableWindow()
     local changed = nil
+    imgui.set_next_window_size({ 480, 640 }, 4) -- 4 is ImGuiCond_FirstUseEver
     if imgui.begin_window(i18n.itemTableWindowTitle, itemWindowOpen, ImGuiWindowFlags_AlwaysAutoResize) then
-        imgui.text(i18n.itemTableWindowTitle)
         imgui.begin_table('search-group', 2, ImGuiTableFlags_NoSavedSettings)
         imgui.table_setup_column('', 0, 2)
         imgui.table_setup_column('', 0, 1)


### PR DESCRIPTION
如图，因为道具表内控件尺寸都是使用自动填充的，所以首次安装插件时道具表窗口宽度计算会变得非常窄，这次修复为道具表窗口提供了初始化默认尺寸

p.s. 没有使用 `ImGuiCond_FirstUseEver` 而是直接传值的原因，参考 https://github.com/praydog/REFramework/issues/1212

![屏幕截图 2025-03-05 151742](https://github.com/user-attachments/assets/7b87ee98-523c-479b-9a8a-22e739daef60)

- fix: set default window size for the item table