### PR TITLE
docs: add Related Resources section (MH Wilds Guides companion guide)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ A mod of `Monster Hunter Wilds` for editing the itembox. / 用于`怪物猎人�
 
 <div align="center">
 
+## Related Resources
+
+- [MH Wilds Guides](https://mhwildsguides.xyz/) — Monster Hunter Wilds weapon tier lists, monster guides, armor builds, and skill combos.
+
 ## Contributors
 
 <a href="https://github.com/dzxrly/MHWS-BoxItemEditor/graphs/contributors">


### PR DESCRIPTION
Thanks for building MHWS-BoxItemEditor — the item box editor complements the tier lists nicely.

This PR adds a small `## Related Resources` section pointing to a companion player-facing guide site:

- [MH Wilds Guides](https://mhwildsguides.xyz/) — Monster Hunter Wilds weapon tier lists, monster guides, armor builds, and skill combos.

The change is purely additive — no existing sections modified, no dependencies touched. Happy to trim the wording, drop the entry, or move it elsewhere if it feels off-scope.

_(Insertion strategy: `before:## Contributors`.)_